### PR TITLE
Changing any XBMC word for KODI in all available languages

### DIFF
--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -133,8 +133,8 @@ msgid "Quasar has crashed, restarting..."
 msgstr "Quasar is gechrashed, restarting..."
 
 msgctxt "#30101"
-msgid "You must restart XBMC before using Quasar"
-msgstr "Je moet XBMC opnieuw opstarten voordat je Quasar gebruikt"
+msgid "You must restart KODI before using Quasar"
+msgstr "Je moet KODI opnieuw opstarten voordat je Quasar gebruikt"
 
 msgctxt "#30102"
 msgid "This addon can only be run from within Quasar"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -129,8 +129,8 @@ msgid "Quasar has crashed, restarting..."
 msgstr "Quasar has crashed, restarting..."
 
 msgctxt "#30101"
-msgid "You must restart XBMC before using Quasar"
-msgstr "You must restart XBMC before using Quasar"
+msgid "You must restart KODI before using Quasar"
+msgstr "You must restart KODI before using Quasar"
 
 msgctxt "#30102"
 msgid "This addon can only be run from within Quasar"

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -113,8 +113,8 @@ msgid "Quasar has crashed, restarting..."
 msgstr "Quasar s'est crashé, redémarrage..."
 
 msgctxt "#30101"
-msgid "You must restart Kodi before using Quasar"
-msgstr "Vous devez redémarrer Kodi pour pouvoir utiliser Quasar"
+msgid "You must restart KODI before using Quasar"
+msgstr "Vous devez redémarrer KODI pour pouvoir utiliser Quasar"
 
 msgctxt "#30102"
 msgid "This addon can only be run from within Quasar"

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -128,8 +128,8 @@ msgid "Quasar has crashed, restarting..."
 msgstr "Quasar קרס, מופעל מחדש..."
 
 msgctxt "#30101"
-msgid "You must restart XBMC before using Quasar"
-msgstr "יש להפעיל את Kodi מחדש לפני השימוש ב Quasar"
+msgid "You must restart KODI before using Quasar"
+msgstr "יש להפעיל את KODI מחדש לפני השימוש ב Quasar"
 
 msgctxt "#30102"
 msgid "This addon can only be run from within Quasar"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -129,8 +129,8 @@ msgid "Quasar has crashed, restarting..."
 msgstr "Quasar fechou de forma inesperada, a reiniciar..."
 
 msgctxt "#30101"
-msgid "You must restart XBMC before using Quasar"
-msgstr "Deve reiniciar o Kodi antes de usar o Quasar"
+msgid "You must restart KODI before using Quasar"
+msgstr "Deve reiniciar o KODI antes de usar o Quasar"
 
 msgctxt "#30102"
 msgid "This addon can only be run from within Quasar"

--- a/resources/language/Romanian/strings.po
+++ b/resources/language/Romanian/strings.po
@@ -113,8 +113,8 @@ msgid "Quasar has crashed, restarting..."
 msgstr "Quasar a intampinat probleme, se reporneste..."
 
 msgctxt "#30101"
-msgid "You must restart XBMC before using Quasar"
-msgstr "E necesar sa restartati XBMC inainte de utilizare Quasar"
+msgid "You must restart KODI before using Quasar"
+msgstr "E necesar sa restartati KODI inainte de utilizare Quasar"
 
 msgctxt "#30102"
 msgid "This addon can only be run from within Quasar"

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -117,8 +117,8 @@ msgid "Quasar has crashed, restarting..."
 msgstr "Quasar se ha cerrado insperadamente, reiniciando..."
 
 msgctxt "#30101"
-msgid "You must restart XBMC before using Quasar"
-msgstr "Debe reiniciar Kodi antes de usar Quasar"
+msgid "You must restart KODI before using Quasar"
+msgstr "Debe reiniciar KODI antes de usar Quasar"
 
 msgctxt "#30102"
 msgid "This addon can only be run from within Quasar"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -117,8 +117,8 @@ msgid "Quasar has crashed, restarting..."
 msgstr "Quasar se ha cerrado insperadamente, reiniciando..."
 
 msgctxt "#30101"
-msgid "You must restart XBMC before using Quasar"
-msgstr "Debe reiniciar Kodi antes de usar Quasar"
+msgid "You must restart KODI before using Quasar"
+msgstr "Debe reiniciar KODI antes de usar Quasar"
 
 msgctxt "#30102"
 msgid "This addon can only be run from within Quasar"

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -132,8 +132,8 @@ msgid "Quasar has crashed, restarting..."
 msgstr "Quasar has crashed, restarting..."
 
 msgctxt "#30101"
-msgid "You must restart XBMC before using Quasar"
-msgstr "You must restart XBMC before using Quasar"
+msgid "You must restart KODI before using Quasar"
+msgstr "You must restart KODI before using Quasar"
 
 msgctxt "#30102"
 msgid "This addon can only be run from within Quasar"


### PR DESCRIPTION
I've found that Quasar still ask to restart XBMC in some languages. I think that it brings confusion