### PR TITLE
Fixed typos and Add torrent string in Croatian translation

### DIFF
--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -143,7 +143,7 @@ msgstr "Učestalost spremanja sesije (sekunde)"
 # Interface
 msgctxt "#30100"
 msgid "Quasar has crashed, restarting..."
-msgstr "Quasarse srušio, ponovno pokrećem..."
+msgstr "Quasar se srušio, ponovno pokrećem..."
 
 msgctxt "#30101"
 msgid "You must restart Kodi before using Quasar"
@@ -224,7 +224,7 @@ msgstr "TV Serije"
 
 msgctxt "#30216"
 msgid "Add Torrent"
-msgstr "Zalijepi URL (Paste)"
+msgstr "Dodaj torrent"
 
 msgctxt "#30217"
 msgid "Paste Magnet or URL"


### PR DESCRIPTION
Fixed typos and Add torrent string in Croatian translation