### PR TITLE
Better daemonize quasar binary by closing non-std inherited files.

### DIFF
--- a/resources/site-packages/quasar/daemon.py
+++ b/resources/site-packages/quasar/daemon.py
@@ -13,9 +13,6 @@ from quasar.config import QUASARD_HOST
 from quasar.addon import ADDON, ADDON_ID
 from quasar.util import notify, system_information, getLocalizedString
 
-SW_HIDE = 0
-STARTF_USESHOWWINDOW = 1
-
 def ensure_exec_perms(file_):
     st = os.stat(file_)
     os.chmod(file_, st.st_mode | stat.S_IEXEC)
@@ -94,6 +91,20 @@ def get_quasar_binary():
 
     return dest_binary_dir, ensure_exec_perms(dest_binary_path)
 
+def clear_fd_inherit_flags():
+    # Ensure the spawned quasar binary doesn't inherit open files from Kodi
+    # which can break things like addon updates. [WINDOWS ONLY]
+    from ctypes import windll
+
+    HANDLE_RANGE = xrange(0, 65536)
+    HANDLE_FLAG_INHERIT = 1
+    FILE_TYPE_DISK = 1
+
+    for hd in HANDLE_RANGE:
+        if windll.kernel32.GetFileType(hd) == FILE_TYPE_DISK:
+            if not windll.kernel32.SetHandleInformation(hd, HANDLE_FLAG_INHERIT, 0):
+                log.error("Error clearing inherit flag, disk file handle %x" % hd)
+
 def start_quasard(**kwargs):
     # Make sure all other quasard instances are closed
     shutdown()
@@ -103,6 +114,9 @@ def start_quasard(**kwargs):
     if quasar_dir is False or quasar_binary is False:
         return False
 
+    SW_HIDE = 0
+    STARTF_USESHOWWINDOW = 1
+
     args = [quasar_binary]
     kwargs["cwd"] = quasar_dir
 
@@ -110,11 +124,13 @@ def start_quasard(**kwargs):
         si = subprocess.STARTUPINFO()
         si.dwFlags = STARTF_USESHOWWINDOW
         si.wShowWindow = SW_HIDE
+        clear_fd_inherit_flags()
         kwargs["startupinfo"] = si
     else:
         env = os.environ.copy()
         env["LD_LIBRARY_PATH"] = "%s:%s" % (quasar_dir, env.get("LD_LIBRARY_PATH", ""))
         kwargs["env"] = env
+        kwargs["close_fds"] = True
 
     return subprocess.Popen(args, **kwargs)
 


### PR DESCRIPTION
Work around problem updating skin addons (#41), addressing both Unix and Windows.  Further discussion is in the issue.