### PR TITLE
added preselect transfer to dialog.select()

### DIFF
--- a/resources/site-packages/quasar/rpc.py
+++ b/resources/site-packages/quasar/rpc.py
@@ -65,11 +65,17 @@ class QuasarRPCServer(BaseHandler):
         dialog = xbmcgui.Dialog()
         return dialog.yesno(getLocalizedLabel(title), getLocalizedLabel(message))
 
-    def Dialog_Select(self, title, items):
+    def Dialog_Select(self, title, items, autoclose=0, preselect=-1):
         dialog = xbmcgui.Dialog()
-        return dialog.select(getLocalizedLabel(title), items)
 
-    def Dialog_Select_Large(self, title, subject, items):
+        # For Kodi <= 16
+        if PLATFORM['kodi'] <= 16:
+            return dialog.select(getLocalizedLabel(title), items)
+        # For Kodi >= 17
+        else:
+            return dialog.select(getLocalizedLabel(title), items, autoclose, preselect)
+
+    def Dialog_Select_Large(self, title, subject, items, autoclose=0, preselect=-1):
         title_encoded = "%s %s" % (getLocalizedLabel(title), toUtf8(subject))
 
         # For Kodi <= 16
@@ -85,7 +91,9 @@ class QuasarRPCServer(BaseHandler):
                                   ADDON_PATH,
                                   "Default",
                                   title=title_encoded,
-                                  items=items)
+                                  items=items,
+                                  autoclose=autoclose,
+                                  preselect=preselect)
         window.doModal()
         retval = window.retval
         del window


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

In Kodi17 python library was adjusted to use preselect in dialog.select() windows.
This commit adds autoclose+preselect parameter binding to use it in future from the daemon.

For Kodi < 17 dialog() logic is the same as it was before.

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
