### PR TITLE
added getShortPath to quasar.util to transform path depending on platform

### DIFF
--- a/resources/site-packages/quasar/daemon.py
+++ b/resources/site-packages/quasar/daemon.py
@@ -12,7 +12,7 @@ from quasar.logger import log
 from quasar.osarch import PLATFORM
 from quasar.config import QUASARD_HOST
 from quasar.addon import ADDON, ADDON_ID, ADDON_PATH
-from quasar.util import notify, system_information, getLocalizedString
+from quasar.util import notify, system_information, getLocalizedString, getWindowsShortPath
 
 def ensure_exec_perms(file_):
     st = os.stat(file_)
@@ -159,6 +159,8 @@ def start_quasard(**kwargs):
     kwargs["cwd"] = quasar_dir
 
     if PLATFORM["os"] == "windows":
+        args[0] = getWindowsShortPath(quasar_binary)
+        kwargs["cwd"] = getWindowsShortPath(quasar_dir)
         si = subprocess.STARTUPINFO()
         si.dwFlags = STARTF_USESHOWWINDOW
         si.wShowWindow = SW_HIDE

--- a/resources/site-packages/quasar/util.py
+++ b/resources/site-packages/quasar/util.py
@@ -46,3 +46,24 @@ def system_information():
     log.info("OS type: %s" % platform.system())
     log.info("uname: %s" % repr(platform.uname()))
     return PLATFORM
+
+def getShortPath(path):
+    if PLATFORM["os"] == "windows":
+        return getWindowsShortPath(path)
+    return path
+
+def getWindowsShortPath(path):
+    import ctypes
+    import ctypes.wintypes
+
+    ctypes.windll.kernel32.GetShortPathNameW.argtypes = [
+        ctypes.wintypes.LPCWSTR,  # lpszLongPath
+        ctypes.wintypes.LPWSTR,  # lpszShortPath
+        ctypes.wintypes.DWORD  # cchBuffer
+    ]
+    ctypes.windll.kernel32.GetShortPathNameW.restype = ctypes.wintypes.DWORD
+
+    buf = ctypes.create_unicode_buffer(1024)  # adjust buffer size, if necessary
+    ctypes.windll.kernel32.GetShortPathNameW(path, buf, len(buf))
+
+    return buf.value


### PR DESCRIPTION
… the platform

<!--- Provide a general summary of your changes in the Title above -->

Added a getOsSpecificPath to quasar.util. 
Used to transform path, depending on the system.
Currently the only platform rule is for Windows.

For Windows:
Using ctype to transform usual path to short path. 

That fixes unicode chars issues, like #702.
Tested with my path, which was not working. 

Providers now can rely on this function to operate on windows with the same Kodi path.

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#702 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
