### PR TITLE
fixed unicode encode for translations

### DIFF
--- a/resources/site-packages/quasar/navigation.py
+++ b/resources/site-packages/quasar/navigation.py
@@ -134,12 +134,12 @@ def run(url_suffix=""):
         else:
             import traceback
             map(log.error, traceback.format_exc().split("\n"))
-            notify(getLocalizedLabel(unicode(e.reason)), time=7000)
+            notify(getLocalizedLabel(unicode(e.reason, 'utf-8')), time=7000)
         return
     except Exception as e:
         import traceback
         map(log.error, traceback.format_exc().split("\n"))
-        notify(getLocalizedLabel(unicode(e)), time=7000)
+        notify(getLocalizedLabel(unicode(e, 'utf-8')), time=7000)
         return
 
     if not data:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When something occur notify() trying to encode string to unicode from 'ascii', which gives more errors.
This change ensures we won't get errors like that.
Seems that is the only place unicode() used.

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
