### PR TITLE
fixed unicode comparison in navigation

### DIFF
--- a/resources/site-packages/quasar/navigation.py
+++ b/resources/site-packages/quasar/navigation.py
@@ -134,7 +134,7 @@ def run(url_suffix=""):
         else:
             import traceback
             map(log.error, traceback.format_exc().split("\n"))
-            notify(getLocalizedLabel(unicode(e.reason, 'utf-8')), time=7000)
+            notify(e.reason, time=7000)
         return
     except Exception as e:
         import traceback
@@ -161,7 +161,7 @@ def run(url_suffix=""):
     for i, item in enumerate(data["items"]):
         # Translate labels
         if item["label"][0:8] == "LOCALIZE":
-            item["label"] = getLocalizedLabel(item["label"])
+            item["label"] = unicode(getLocalizedLabel(item["label"]), 'utf-8')
         if item["label2"][0:8] == "LOCALIZE":
             item["label2"] = getLocalizedLabel(item["label2"])
 
@@ -173,7 +173,7 @@ def run(url_suffix=""):
                 listItem.addStreamInfo(type_, values)
         if item.get("art"):
             listItem.setArt(item["art"])
-        elif ADDON.getSetting('default_fanart') == 'true' and item["label"] != getLocalizedString(30218):
+        elif ADDON.getSetting('default_fanart') == 'true' and item["label"] != unicode(getLocalizedString(30218), 'utf-8'):
             fanart = os.path.join(ADDON_PATH, "fanart.jpg")
             listItem.setArt({'fanart': fanart})
         if item.get("context_menu"):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Sometimes navigation gets to a "fanart" comparison and throws an error regarding unicode conversion fault, so we transform all non-unicode fields to unicode (they can be both unicode and non-unicode). 

Checked with cyrillic names and latin, works for me.

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
