### PR TITLE
added real-path resolver for addon properties

### DIFF
--- a/resources/site-packages/quasar/addon.py
+++ b/resources/site-packages/quasar/addon.py
@@ -1,7 +1,13 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
 import xbmcaddon
 
 ADDON = xbmcaddon.Addon()
 ADDON_ID = ADDON.getAddonInfo("id")
 ADDON_NAME = ADDON.getAddonInfo("name")
-ADDON_PATH = ADDON.getAddonInfo("path").decode('utf-8')
 ADDON_ICON = ADDON.getAddonInfo("icon").decode('utf-8')
+try:
+    ADDON_PATH = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__).decode(sys.getfilesystemencoding(), 'ignore')), "..", "..", ".."))
+except:
+    ADDON_PATH = ADDON.getAddonInfo("path").decode('utf-8')

--- a/resources/site-packages/quasar/rpc.py
+++ b/resources/site-packages/quasar/rpc.py
@@ -136,9 +136,10 @@ class QuasarRPCServer(BaseHandler):
     def GetAddonInfo(self):
         info = {}
         for key in ("author", "changelog", "description", "disclaimer",
-                    "fanart", "icon", "id", "name", "path", "profile", "stars",
+                    "fanart", "icon", "id", "name", "profile", "stars",
                     "summary", "type", "version"):
             info[key] = ADDON.getAddonInfo(key)
+        info['path'] = ADDON_PATH
         return info
 
     def AddonFailure(self, addonId):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

ADDON_PATH is resolved by real script location.
Chain: 
- get real script location
- decode into utf-8, depending on filesystemencoding (yes, that is another one, related to files and their paths)
- get it's directory
- browse 3 levels under

That path does not need to be encoded/decoded when opening files, as long as the script has a "utf-8" header on the first line.

Tests on windows with cyrillic profile. Daemon started, I can browse Quasar, start a play, video is played.
When I stop if - Quasar crashes. - http://paste.ubuntu.com/24058516/

So need to adjust the daemon, python should work fine.

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
