### PR TITLE
added description for binary not found. added activatewindow() 

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -428,7 +428,7 @@ msgid "This add-on can only be run from within Quasar"
 msgstr ""
 
 msgctxt "#30103"
-msgid "Unable to find Quasar binary"
+msgid "Unable to find Quasar binary[CR]Required platform:"
 msgstr ""
 
 msgctxt "#30104"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -406,8 +406,8 @@ msgid "This add-on can only be run from within Quasar"
 msgstr "Это дополниние можно запустить только через Quasar"
 
 msgctxt "#30103"
-msgid "Unable to find Quasar binary"
-msgstr "Quasar binary не найден"
+msgid "Unable to find Quasar binary[CR]Required platform:"
+msgstr "Quasar binary не найден[CR]Требуемая платформа:"
 
 msgctxt "#30104"
 msgid "Insert file or URL"

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -406,8 +406,8 @@ msgid "This add-on can only be run from within Quasar"
 msgstr "Це доповнення можна запустити тілько через Quasar"
 
 msgctxt "#30103"
-msgid "Unable to find Quasar binary"
-msgstr "Quasar binary не знайдений"
+msgid "Unable to find Quasar binary[CR]Required platform:"
+msgstr "Quasar binary не знайдений[CR]Необхідна платформа:"
 
 msgctxt "#30104"
 msgid "Insert file or URL"

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -432,7 +432,7 @@ msgid "This add-on can only be run from within Quasar"
 msgstr ""
 
 msgctxt "#30103"
-msgid "Unable to find Quasar binary"
+msgid "Unable to find Quasar binary[CR]Required platform:"
 msgstr ""
 
 msgctxt "#30104"

--- a/resources/site-packages/quasar/daemon.py
+++ b/resources/site-packages/quasar/daemon.py
@@ -48,7 +48,7 @@ def get_quasar_binary():
     dest_binary_path = os.path.join(dest_binary_dir, binary)
 
     if not os.path.exists(binary_path):
-        notify(getLocalizedString(30103))
+        notify((getLocalizedString(30103) + " %(os)s_%(arch)s" % PLATFORM), time=7000)
         system_information()
         return False, False
 
@@ -119,6 +119,7 @@ def jsonrpc_enabled(notify=False):
     except Exception as e:
         log.error(repr(e))
         if notify:
+            xbmc.executebuiltin("ActivateWindow(ServiceSettings)")
             dialog = xbmcgui.Dialog()
             dialog.ok("Quasar", getLocalizedString(30199))
     return False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added new string in messages to show desired Platform when binary not found.
When remote control check fails - Opening Settings window.

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
