### PR TITLE
fixed unicode path usage in overlay.py

### DIFF
--- a/resources/site-packages/quasar/overlay.py
+++ b/resources/site-packages/quasar/overlay.py
@@ -27,7 +27,7 @@ class OverlayText(object):
         self._shadow = xbmcgui.ControlLabel(x + 1, y + 1, w, h, self._text,
                                             textColor='0xD0000000',
                                             alignment=XBFONT_CENTER_X | XBFONT_CENTER_Y, *args, **kwargs)
-        self._background = xbmcgui.ControlImage(x, y, w, h, os.path.join(ADDON_PATH, "resources", "img", "black.png"))
+        self._background = xbmcgui.ControlImage(x, y, w, h, os.path.join(ADDON_PATH, "resources", "img", "black.png").encode('utf-8'))
         self._background.setColorDiffuse("0xD0000000")
 
     def show(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

If profile path contains unicode chars then in overlay.py we get a Unicode from xbmcgui.ControlImage(), somehow it does not treat the path well.

Looked over other places in python scripts, they look fine, and do not throw any error.

Fixes #781 

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
