### PR TITLE
Wait until add-on settings window is closed before running the daemon

### DIFF
--- a/resources/site-packages/quasar/daemon.py
+++ b/resources/site-packages/quasar/daemon.py
@@ -181,6 +181,14 @@ def start_quasard(**kwargs):
         kwargs["env"] = env
         kwargs["close_fds"] = True
 
+    wait_counter = 1
+    while xbmc.getCondVisibility('Window.IsVisible(10140)'):
+        if wait_counter == 1:
+            log.info('Add-on settings currently opened, waiting before starting...')
+        if wait_counter > 300:
+            break
+        time.sleep(1)
+
     return subprocess.Popen(args, **kwargs)
 
 def shutdown():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently we face multiple daemon restart tries when it's a new installation. 
This change checks for addon settings being active, and wait till it's closed, before starting the daemon.


<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
