### PR TITLE
fixed not-fully described season/episode in play links

### DIFF
--- a/resources/site-packages/quasar/navigation.py
+++ b/resources/site-packages/quasar/navigation.py
@@ -80,10 +80,12 @@ def getInfoLabels():
             url = "%s/infolabels" % (QUASARD_HOST)
     elif 'movie' in sys.argv[0]:
         url = "%s/movie/%s/infolabels" % (QUASARD_HOST, tmdb_id)
-    elif 'episode' in sys.argv[0] or ('show' in sys.argv[0] and id_list[1] and id_list[2]):
-        url = "%s/show/%s/season/%s/episode/%s/infolabels" % (QUASARD_HOST, tmdb_id, id_list[1], id_list[2])
+    elif ('episode' in sys.argv[0] or 'show' in sys.argv[0]) and len(id_list) > 2:
+        url = "%s/show/%s/season/%s/episode/%s/infolabels" % (QUASARD_HOST, tmdb_id, id_list[0], id_list[2])
+    elif 'show' in sys.argv[0] and len(id_list) == 2:
+        url = "%s/show/%s/season/%s/episode/%s/infolabels" % (QUASARD_HOST, tmdb_id, id_list[1], 1)
     else:
-        url = "%s/show/%s/infolabels" % (QUASARD_HOST, tmdb_id)
+        url = "%s/infolabels" % (QUASARD_HOST)
 
     log.debug("Resolving TMDB item by calling %s for %s" % (url, repr(sys.argv)))
 
@@ -107,6 +109,11 @@ def getInfoLabels():
                 del resolved['art']
             if 'stream_info' in resolved:
                 del resolved['stream_info']
+
+            if 'DBTYPE' not in resolved:
+                resolved['DBTYPE'] = 'video'
+            if 'Mediatype' not in resolved:
+                resolved['Mediatype'] = 'video'
 
             return resolved
     except:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes getting infolabels for play url without episode number or season not defined. Using default "1" numbers.
Fixed #826 

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
