### PR TITLE
fix for watched state setters

### DIFF
--- a/resources/site-packages/quasar/navigation.py
+++ b/resources/site-packages/quasar/navigation.py
@@ -25,7 +25,7 @@ class InfoLabels(dict):
         self.update(*args, **kwargs)
 
     def __getitem__(self, key):
-        return dict.get(self, key.lower())
+        return dict.get(self, key.lower(), "")
 
     def __setitem__(self, key, val):
         dict.__setitem__(self, key.lower(), val)
@@ -63,7 +63,9 @@ def getInfoLabels():
     id_list = [int(s) for s in sys.argv[0].split("/") if s.isdigit()]
     tmdb_id = id_list[0] if id_list else None
 
-    if not tmdb_id:
+    if xbmc.getInfoLabel("ListItem.DBID"):
+        url = "%s/infolabels" % (QUASARD_HOST)
+    elif not tmdb_id:
         parsed_url = urlparse.urlparse(sys.argv[0] + sys.argv[2])
         query = urlparse.parse_qs(parsed_url.query)
         log.debug("Parsed URL: %s, Query: %s", repr(parsed_url), repr(query))
@@ -91,7 +93,7 @@ def getInfoLabels():
 
     try:
         with closing(urllib2.urlopen(url)) as response:
-            resolved = json.loads(response.read())
+            resolved = json.loads(response.read(), parse_int=str)
             if not resolved:
                 return {}
 
@@ -112,8 +114,8 @@ def getInfoLabels():
 
             if 'DBTYPE' not in resolved:
                 resolved['DBTYPE'] = 'video'
-            if 'Mediatype' not in resolved:
-                resolved['Mediatype'] = 'video'
+            if 'mediatype' not in resolved or resolved['mediatype'] == '':
+                resolved['mediatype'] = resolved['DBTYPE']
 
             return resolved
     except:
@@ -124,6 +126,10 @@ def getInfoLabels():
 def _json(url):
     with closing(urllib2.urlopen(url)) as response:
         if response.code >= 300 and response.code <= 307:
+            # Pause currently playing Quasar file to avoid doubling requests
+            if xbmc.Player().isPlaying() and ADDON_ID in xbmc.Player().getPlayingFile():
+                xbmc.Player().pause()
+
             _infoLabels = InfoLabels(getInfoLabels())
 
             item = xbmcgui.ListItem(
@@ -166,10 +172,6 @@ def run(url_suffix=""):
 
     socket.setdefaulttimeout(int(ADDON.getSetting("buffer_timeout")))
     urllib2.install_opener(urllib2.build_opener(NoRedirectHandler()))
-
-    # Pause currently playing Quasar file to avoid doubling requests
-    if xbmc.Player().isPlaying() and ADDON_ID in xbmc.Player().getPlayingFile():
-        xbmc.Player().pause()
 
     url = sys.argv[0].replace("plugin://%s" % ADDON_ID, QUASARD_HOST + url_suffix) + sys.argv[2]
     log.debug("Requesting %s from %s" % (url, repr(sys.argv)))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #833, #832, #821 and other issues, connected with watched state. 

<!--- Pull requests for translations can skip the following, simply title
      your pull request as "Translation update for [language]" and squash
      your commits into a single one with the same title, if possible. -->

## Description
<!--- Describe your changes in detail -->

Changes in plugin:
- If item was called from Kodi library - information is used "as is", proxying all the data to the player.
- Fixed setting integer values, Player.setInfo() needs all as string, so int values were skipped.
- Moved Player.Pause() to be executed only on /play urls (so when item is played and you browse Quasar - video will not be paused automatically).

Changes in backend:
- Watched status is updated on every torrentfs close(), but now we take DBID, DBTYPE from Player() (those fields are now correctly set by navigation.py and are describing currently playing item).
- Moved UniqueId getter for TVShows to separate function.
- If TMDB item does not have TVDB Id link (for example, for new episodes), then we try to iterate Show's episodes and match by Season+Episode.


Would be great to involve users to testing. @KillerJoeBR, maybe?

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
